### PR TITLE
Trying to fix indication - take 2

### DIFF
--- a/dot15d4-cat/.cargo/config.toml
+++ b/dot15d4-cat/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-gnu"

--- a/dot15d4-macros/.cargo/config.toml
+++ b/dot15d4-macros/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/dot15d4/.cargo/config.toml
+++ b/dot15d4/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/dot15d4/src/lib.rs
+++ b/dot15d4/src/lib.rs
@@ -59,8 +59,6 @@ where
 {
     pub async fn run(&mut self) -> ! {
         #[cfg(feature = "rtos-trace")]
-        rtos_trace::trace::marker_end(0);
-
         #[cfg(feature = "rtos-trace")]
         self::trace::instrument();
 

--- a/dot15d4/src/mac/mcps/data.rs
+++ b/dot15d4/src/mac/mcps/data.rs
@@ -69,10 +69,10 @@ where
         })
     }
 
-    pub async fn mcps_data_indication(&self, indication: &mut DataIndication) {
+    pub async fn mcps_data_indication(&self, indication: DataIndication) {
         self.upper_layer
             .process_mac_indication(crate::mac::primitives::MacIndication::McpsData(
-                core::mem::take(indication),
+                indication,
             ))
             .await;
     }

--- a/dot15d4/src/mac/mlme/beacon.rs
+++ b/dot15d4/src/mac/mlme/beacon.rs
@@ -45,7 +45,7 @@ where
 
     pub(crate) async fn mlme_beacon_notify_indication(
         &self,
-        _indication: &mut BeaconNotifyIndication,
+        _indication: BeaconNotifyIndication,
     ) {
         // TODO: support Beacon Notify indication
         info!("Received Beacon Notification");

--- a/dot15d4/src/phy/mod.rs
+++ b/dot15d4/src/phy/mod.rs
@@ -106,7 +106,7 @@ where
 {
     /// Run the main event loop used by the PHY sublayer for its operation. For
     /// now, the loop waits for either receiving a frame from the MAC sublayer
-    ///  or receiving a frame from the radio.
+    /// or receiving a frame from the radio.
     pub async fn run(&mut self) -> ! {
         self.radio.get_mut().enable().await; // Wake up radio
         let mut radio_guard = self.radio.lock().await;

--- a/fuzz/.cargo/config.toml
+++ b/fuzz/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Hi Jérémy,

this is my second tentative to get the indication refactoring right. I let the unit tests run - those are ok now. But I cannot this on hardware until I integrated the updated frame parsing - can you?

This PR also contains two minor changes that I did on-the-fly:
- minimal whitespace typo
- default configuration for cargo for the different crates (some run on Linux, others on the hardware)